### PR TITLE
Turn useragent lowercase to match against crawler signatures

### DIFF
--- a/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
+++ b/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
@@ -177,7 +177,7 @@ page_views as (
   where event = 'page_view'
     and (br_family != 'Robot/Spider' or br_family is null)
     and (
-        not regexp_contains(useragent, '^.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt).*$')
+        not regexp_contains(LOWER(useragent), '^.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|phantomjs|yandexbot|twitterbot|a_archiver|facebookexternalhit|bingbot|bingpreview|googlebot|baiduspider|360(spider|user-agent)|semalt).*$')
         or useragent is null
     )
     and domain_userid is not null


### PR DESCRIPTION
Turn the **useragent** string to lower case before matching against crawler signatures to make it more resilient against uppercase/lowercase variations